### PR TITLE
Use autometrics http middleware

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,43 +1,56 @@
 package main
 
 import (
-    "encoding/json"
-    "net/http"
-    "time"
-	"github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
+	"encoding/json"
+	"net/http"
+	"time"
 
+	"github.com/autometrics-dev/autometrics-go/prometheus/autometrics"
+	"github.com/autometrics-dev/autometrics-go/prometheus/midhttp"
 )
 
 //go:generate autometrics
 
 func main() {
-
 	autometrics.Init(
-			nil,
-			autometrics.DefBuckets,
-			autometrics.BuildInfo{Version: "0.4.0", Commit: "anySHA", Branch: ""},
-		)
-    http.HandleFunc("/json", jsonHandler)
-    http.HandleFunc("/error", errorHandler)
-    http.HandleFunc("/slow", slowHandler)
+		nil,
+		autometrics.DefBuckets,
+		autometrics.BuildInfo{Version: "0.4.0", Commit: "anySHA", Branch: ""},
+	)
 
-    http.ListenAndServe(":8080", nil)
+	http.Handle("/json", midhttp.Autometrics(
+		http.HandlerFunc(jsonHandler),
+		autometrics.WithSloName("API"),
+		autometrics.WithAlertLatency(100*time.Millisecond, 0.99),
+	))
+	http.Handle("/error", midhttp.Autometrics(
+		http.HandlerFunc(errorHandler),
+		autometrics.WithSloName("API"),
+		autometrics.WithAlertLatency(100*time.Millisecond, 0.99),
+	))
+	http.Handle("/slow", midhttp.Autometrics(
+		http.HandlerFunc(slowHandler),
+		autometrics.WithSloName("API"),
+		autometrics.WithAlertLatency(100*time.Millisecond, 0.99),
+	))
+
+	http.ListenAndServe(":8080", nil)
 }
 
-//autometrics:inst --slo "API" --latency-target 99 --latency-ms 100
+// jsonHandler is the handler function for the '/json' endpoint.
 func jsonHandler(w http.ResponseWriter, r *http.Request) {
-    data := map[string]string{"message": "Hello, World!"}
-    json.NewEncoder(w).Encode(data)
+	data := map[string]string{"message": "Hello, World!"}
+	json.NewEncoder(w).Encode(data)
 }
 
-//autometrics:inst --slo "API" --latency-target 99 --latency-ms 100
+// errorHandler is the handler function for the '/error' endpoint.
 func errorHandler(w http.ResponseWriter, r *http.Request) {
-    http.Error(w, "Oops! Something went wrong.", http.StatusInternalServerError)
+	http.Error(w, "Oops! Something went wrong.", http.StatusInternalServerError)
 }
 
-//autometrics:inst --slo "API" --latency-target 99 --latency-ms 100
+// slowHandler is the handler function for the '/slow' endpoint.
 func slowHandler(w http.ResponseWriter, r *http.Request) {
-    time.Sleep(5 * time.Second)
-    data := map[string]string{"message": "This response took 5 seconds to generate."}
-    json.NewEncoder(w).Encode(data)
+	time.Sleep(5 * time.Second)
+	data := map[string]string{"message": "This response took 5 seconds to generate."}
+	json.NewEncoder(w).Encode(data)
 }


### PR DESCRIPTION
- extra changes likely come from the stricter gofmt (-s -w)

- there is currently no way in autometrics-go to generate only the documentation part for a function, so there is no way to get the links in the doc comment for the http handlers easily. This is a feature that needs to be added in autometrics-go.

- the middleware still has to be used, as it is the only way to reliably track the success of http handlers.